### PR TITLE
Use config for JSX runtime since we use it in most projects

### DIFF
--- a/packages/eslint-config-react/index.js
+++ b/packages/eslint-config-react/index.js
@@ -1,7 +1,10 @@
 const eslintConfig = require('@thetribe/eslint-config');
 
 module.exports = {
-    extends: 'airbnb',
+    extends: [
+        'airbnb',
+        'plugin:react/jsx-runtime',
+    ],
     rules: {
         // We don't use extends to prevent airbnb-base from overriding some config from airbnb
         ...eslintConfig.rules,


### PR DESCRIPTION
This removes the need to import the React symbol in all JSX files.