### PR TITLE
Add typescript-eslint no-floating-promisses rule

### DIFF
--- a/packages/eslint-config-typescript/index.js
+++ b/packages/eslint-config-typescript/index.js
@@ -33,6 +33,8 @@ module.exports = {
         // Replace default-case with switch-exhaustiveness-check
         '@typescript-eslint/switch-exhaustiveness-check': 'error',
         'default-case': 'off',
+        // Add rules that are only possible with typescript
+        '@typescript-eslint/no-floating-promises': ['error'],
     },
     settings: {
         'import/extensions': [


### PR DESCRIPTION
Promises should always be handled either by beeing awaited or by using a catch with erreur handling in case they need to be handled asynchronously.