### PR TITLE
Use @typescript-eslint version of quotes rule

### DIFF
--- a/packages/eslint-config-typescript/index.js
+++ b/packages/eslint-config-typescript/index.js
@@ -20,9 +20,13 @@ module.exports = {
             classes: true,
             variables: true,
         }],
+        '@typescript-eslint/quotes': ['error', 'single', {
+            avoidEscape: true,
+        }],
         'no-shadow': 'off',
         'no-unused-vars': 'off',
         'no-use-before-define': 'off',
+        'quotes': 'off',
         // Add ts to allowed extensions
         'import/extensions': ['error', 'ignorePackages', {
             cjs: 'never',


### PR DESCRIPTION
This should fix the rule not replacing quotes for some typescript-specific language constructs (like `import type`).